### PR TITLE
Add Development Server using express and iojs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+bower_components
+node_modules

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "buffy",
+  "version": "1.0.0",
+  "description": "- bower install - npm start",
+  "main": "text selection.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "iojs server.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/pearvert/buffy.git"
+  },
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/pearvert/buffy/issues"
+  },
+  "homepage": "https://github.com/pearvert/buffy#readme",
+  "devDependencies": {
+    "express": "^4.13.0",
+    "serve-index": "^1.7.0"
+  }
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,19 @@
+var express = require('express');
+var serveIndex = require('serve-index');
+var app = express();
+
+app.use(express.static('./'));
+app.use('/', serveIndex('./'));
+
+app.get('/express', function (req, res) {
+  res.send('Hello World!');
+});
+
+var server = app.listen(3000, function () {
+
+  var host = server.address().address;
+  var port = server.address().port;
+
+  console.log('Example app listening at http://%s:%s', host, port);
+
+});


### PR DESCRIPTION
Adds package.json and a development server built off express

`npm start` is default to run with `iojs` so you may need to install that via `nvm` or `homebrew`
